### PR TITLE
fix(ci): update workflows for actions/checkout@v7 unsafe-pr support

### DIFF
--- a/.github/workflows/net-utils-builder-staging.yml
+++ b/.github/workflows/net-utils-builder-staging.yml
@@ -14,14 +14,16 @@ jobs:
       contents: read
       pull-requests: write
 
-    # safe to use pull_request_target because we only run this for trusted collaborators
-    if: contains(fromJson('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Set up QEMU for multi-arch builds
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/utilities-unit-tests.yml
+++ b/.github/workflows/utilities-unit-tests.yml
@@ -15,6 +15,8 @@ jobs:
     name: Run Utilities Unit Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read
@@ -27,6 +29,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0

--- a/.github/workflows/validate-coderabbit-schema.yml
+++ b/.github/workflows/validate-coderabbit-schema.yml
@@ -14,6 +14,8 @@ jobs:
     name: Validate .coderabbit.yaml against schema
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Org members run automatically; outside contributors need maintainer approval
+    environment: ${{ (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && !contains(fromJSON('["COLLABORATOR","MEMBER","OWNER"]'), github.event.pull_request.author_association)) && 'external-pr-tests' || '' }}
     permissions:
       contents: read
       pull-requests: read
@@ -23,6 +25,8 @@ jobs:
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: true
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@v8.2.0


### PR DESCRIPTION
##### What this PR does / why we need it:
Fixes three CI workflows that broke after upgrading from `actions/checkout@v6` to `actions/checkout@v7`. The new version requires explicit opt-in for checking out untrusted PR code via `allow-unsafe-pr-checkout: true`, and adds `persist-credentials: false` for security. Also replaces the `CONTRIBUTOR` association check with a GitHub environment gate (`external-pr-tests`) so that outside contributors must receive maintainer approval before workflows run with secrets.

Affected workflows:
- `.github/workflows/net-utils-builder-staging.yml`
- `.github/workflows/utilities-unit-tests.yml`
- `.github/workflows/validate-coderabbit-schema.yml`

##### Which issue(s) this PR fixes:

##### Special notes for reviewer:

##### jira-ticket:
NONE

Made with [Cursor](https://cursor.com)